### PR TITLE
Remove 'Data Services Validator Project' from Context Menu

### DIFF
--- a/plugins/org.wso2.developerstudio.eclipse.artifact.dataservice.validator/plugin.xml
+++ b/plugins/org.wso2.developerstudio.eclipse.artifact.dataservice.validator/plugin.xml
@@ -53,7 +53,7 @@
 		</navigatorContent>
 	</extension>-->
 			<extension point="org.eclipse.ui.navigator.navigatorContent">    
-            <commonWizard type="new"
+            <!--commonWizard type="new"
                 menuGroupId="1org.wso2.developerstudio.eclipse.artifact.webservice"
                 wizardId="org.wso2.developerstudio.eclipse.artifact.newvalidiatorartifact">
                 <enablement>
@@ -68,7 +68,7 @@
 						</adapt>
                     </or>
                 </enablement>
-            </commonWizard>
+            </commonWizard-->
     </extension>
    	 <extension
          point="org.wso2.developerstudio.eclipse.project.export.handler">


### PR DESCRIPTION
## Purpose
Remove 'Data Services Validator Project' from Context Menu which opens up upon right clicking a data service project.