### PR TITLE
Disable click outside of bootstrap modal area to close modal

### DIFF
--- a/plugins/org.wso2.developerstudio.eclipse.ds.editor/DSSEditor/assets/js/data-handler.js
+++ b/plugins/org.wso2.developerstudio.eclipse.ds.editor/DSSEditor/assets/js/data-handler.js
@@ -725,6 +725,7 @@ $(document).ready(function ($) {
         updateInputMappingTable();
 
         $("#q-im-addedit-title").text("Add Input Mapping");
+        $('#q-input-mapping-modal').modal({backdrop: 'static', show: false});
         $("#q-input-mapping-modal").modal("show");
     });
 
@@ -902,6 +903,7 @@ function openResourcesModal(isEditEnabled) {
     } else {
         $("#resource-modal-header").text("Create Resource");
     }
+    $('#r-resource-addedit-modal').modal({backdrop: 'static', show: false});
     $("#r-resource-addedit-modal").modal('show');
 }
 
@@ -1390,6 +1392,7 @@ function showNotificationAlertModal(title, content) {
     $("#alert-modal-title").text(title);
     $("#alert-modal-content").text(content);
 
+    $('#alert-modal').modal({backdrop: 'static', show: false});
     $("#alert-modal").modal('show');
 }
 

--- a/plugins/org.wso2.developerstudio.eclipse.ds.editor/DSSEditor/assets/js/datasources-util.js
+++ b/plugins/org.wso2.developerstudio.eclipse.ds.editor/DSSEditor/assets/js/datasources-util.js
@@ -11,6 +11,7 @@ function openDSModal(isEditEnabled) {
         $("#ds-ds-id-input").prop('disabled', false);
     }
 
+    $('#ds-add-edit-ds-modal').modal({backdrop: 'static', show: false});  
     $("#ds-add-edit-ds-modal").modal('show');
 }
 

--- a/plugins/org.wso2.developerstudio.eclipse.ds.editor/DSSEditor/assets/js/operation-validation.js
+++ b/plugins/org.wso2.developerstudio.eclipse.ds.editor/DSSEditor/assets/js/operation-validation.js
@@ -243,6 +243,7 @@ function populateOperationForm(root, operation_name, query_name) {
 					$('#op-addedit-returnreqstatus-checkbox').prop("checked", false);
 				}
 				
+				$('#o-operation-addedit-modal').modal({backdrop: 'static', show: false});
 				$("#o-operation-addedit-modal").modal('show');
 			}
 		}

--- a/plugins/org.wso2.developerstudio.eclipse.ds.editor/DSSEditor/assets/js/q-output-mapping-validation.js
+++ b/plugins/org.wso2.developerstudio.eclipse.ds.editor/DSSEditor/assets/js/q-output-mapping-validation.js
@@ -294,6 +294,7 @@ function populateQueryOutputMappingModal(result, tds, root) {
 		populateOutputMappingModal(root, false);
 	}
 	
+	$("#q-output-mapping-modal").modal({backdrop: 'static', show: false});
 	$("#q-output-mapping-modal").modal('show');
 }
 

--- a/plugins/org.wso2.developerstudio.eclipse.ds.editor/DSSEditor/assets/js/query-util.js
+++ b/plugins/org.wso2.developerstudio.eclipse.ds.editor/DSSEditor/assets/js/query-util.js
@@ -419,6 +419,7 @@ function editInputMapping(root, mappingName) {
 
     window.isInputMappingEdit = true;
     window.mappingToBeDeleted = mappingName;
+    $('#q-input-mapping-modal').modal({backdrop: 'static', show: false});
     $("#q-input-mapping-modal").modal("show");
 }
 

--- a/plugins/org.wso2.developerstudio.eclipse.ds.editor/DSSEditor/index.html
+++ b/plugins/org.wso2.developerstudio.eclipse.ds.editor/DSSEditor/index.html
@@ -205,7 +205,7 @@
                                 </tbody>
                             </table>
                         </div>
-                        <div class="text-right"><button class="btn btn-secondary btn-sm" type="button" id="q-output_mapping-gen-btn" >Generate</button><button class="btn btn-success btn-sm" type="button" id="q-output_mapping-add-btn" data-toggle="modal" data-target="#q-output-mapping-modal">Add New</button></div>
+                        <div class="text-right"><button class="btn btn-secondary btn-sm" type="button" id="q-output_mapping-gen-btn" >Generate</button><button class="btn btn-success btn-sm" type="button" id="q-output_mapping-add-btn" data-toggle="modal" data-target="#q-output-mapping-modal" data-keyboard="false" data-backdrop="static">Add New</button></div>
                     </div>
                 </div>
                 <div class="collapse-custom"><a class="btn btn-primary btn-collapse-header" data-toggle="collapse" aria-expanded="false" aria-controls="om-advanced-properties-collapse" role="button" href="#om-advanced-properties-collapse">Advanced Properties</a>
@@ -258,7 +258,7 @@
                 </table>
             </div>
             <div id="o-table-notification-alert-holder" class="alert mr-auto" style="padding-right: 0;padding-left: 0;margin-bottom: 0;padding-bottom: 0;"></div>
-            <div class="text-right"><button class="btn btn-success btn-sm" type="button" id="o-operation-add-btn" data-toggle="modal" data-target="#o-operation-addedit-modal">Add New</button></div>
+            <div class="text-right"><button class="btn btn-success btn-sm" type="button" id="o-operation-add-btn" data-toggle="modal" data-target="#o-operation-addedit-modal" data-keyboard="false" data-backdrop="static">Add New</button></div>
         </div>
     </div>
     <div id="resources" class="collapse-custom"><a class="btn btn-primary btn-collapse-header" data-toggle="collapse" aria-expanded="false" aria-controls="resources-collapse" role="button" href="#resources-collapse">Resources</a>
@@ -284,7 +284,7 @@
                 </table>
             </div>
             <div id="resource-table-notification-alert-holder" class="alert mr-auto" style="padding-right: 0;padding-left: 0;margin-bottom: 0;padding-bottom: 0;"></div>
-            <div class="text-right"><button class="btn btn-success btn-sm" type="button" id="r-resource-add-btn" data-toggle="modal">Add New</button></div>
+            <div class="text-right"><button class="btn btn-success btn-sm" type="button" id="r-resource-add-btn" data-toggle="modal" >Add New</button></div>
         </div>
     </div>
     <div id="advanced-config-collapse" class="collapse-custom"><a class="btn btn-primary btn-collapse-header" data-toggle="collapse" aria-expanded="false" aria-controls="advanced-settings-collapse" role="button" href="#advanced-settings-collapse">Advanced Configurations</a>


### PR DESCRIPTION
## Purpose
> This PR is related to the disabling click outside of the bootstrap modal area to close modal in DSS editor