### PR TITLE
Fixed: Issue 767

### DIFF
--- a/plugins/org.wso2.developerstudio.eclipse.ds.editor/DSSEditor/assets/js/data-handler.js
+++ b/plugins/org.wso2.developerstudio.eclipse.ds.editor/DSSEditor/assets/js/data-handler.js
@@ -890,18 +890,10 @@ function populateTransportSettings(root) {
 
     if (transports !== undefined && transports !== null) {
         transportValues = transports.value.split(" ");
-        transportValues.forEach(function (item, index) {
-            item = item.trim();
-            if (item.toLowerCase() == "http") {
-                $('#ts-http-check').prop('checked', true);
-            } else if (item.toLowerCase() == "https") {
-                $('#ts-https-check').prop('checked', true);
-            } else if (item.toLowerCase() == "local") {
-                $('#ts-local-check').prop('checked', true);
-            } else if (item.toLowerCase() == "jms") {
-                $('#ts-jms-check').prop('checked', true);
-            }
-        });
+        $('#ts-http-check').prop('checked', (transportValues.indexOf("http") >= 0));
+        $('#ts-https-check').prop('checked', (transportValues.indexOf("https") >= 0));
+        $('#ts-local-check').prop('checked', (transportValues.indexOf("local") >= 0));
+        $('#ts-jms-check').prop('checked', (transportValues.indexOf("jms") >=0 ));
     }
     
     let txManagerJNDIName = root.getElementsByTagName("data")[0].attributes.getNamedItem("txManagerJNDIName");


### PR DESCRIPTION
When a transport protocol was deleted in the source view, changes are not reflected in the design view. The reason is that it only check for added transport protocols and does not clear removed ones.

Related Issue: https://github.com/wso2/devstudio-tooling-ei/issues/767