### PR TITLE
Fixed: Issue 766

### DIFF
--- a/plugins/org.wso2.developerstudio.eclipse.ds.editor/DSSEditor/assets/js/data-handler.js
+++ b/plugins/org.wso2.developerstudio.eclipse.ds.editor/DSSEditor/assets/js/data-handler.js
@@ -1100,6 +1100,7 @@ function replaceNode(newNode, refNode) {
  */
 function saveAll(root, url, successFunc) {
     let serializedData = new XMLSerializer().serializeToString(root);
+    serializedData = serializedData.split(/xmlns\:NS[0-9]+=\"\" NS[0-9]+\:/).join("");
     let prettyXmlText;
     let isIE = false || !!document.documentMode;
 


### PR DESCRIPTION
XMLSerializer in the IE adds prefix 'xmlns:NS#num="" NS#num:' when there is a colon (:) in an attribute name. Removed any such prefix.

Related Issue: https://github.com/wso2/devstudio-tooling-ei/issues/766