### PR TITLE
Fixed: Issue 788

### DIFF
--- a/plugins/org.wso2.developerstudio.eclipse.ds.editor/DSSEditor/assets/js/data-handler.js
+++ b/plugins/org.wso2.developerstudio.eclipse.ds.editor/DSSEditor/assets/js/data-handler.js
@@ -258,6 +258,7 @@ $(document).ready(function ($) {
         e.preventDefault();
         let dbEngineType = $("#ds-db-engine-select").val();
         populateDBEngineDefaults(root, dbEngineType);
+        setTestConnectionRDBMSVersion(dbEngineType);
     });
     
     // End of Data sources - Add data source

--- a/plugins/org.wso2.developerstudio.eclipse.ds.editor/DSSEditor/assets/js/datasources-util.js
+++ b/plugins/org.wso2.developerstudio.eclipse.ds.editor/DSSEditor/assets/js/datasources-util.js
@@ -610,6 +610,36 @@ function populateDBEngineDefaults(root, dbEngineType) {
 }
 
 /**
+ * This function is used to set the test connection RDBMS Version once the Database Engine is selected.
+ *
+ * @param dbEngineType Database Engine type.
+ */
+function setTestConnectionRDBMSVersion(dbEngineType) {
+    let testRDBMSversion;
+    let testRDBMSVersionSelector = $("#ds-db-version-select");
+    switch (dbEngineType) {
+    case DB_ENGINE_MYSQL:
+        testRDBMSversion = testRDBMSVersionSelector.find("[label='MySQL']").children()[0].value;
+        break;
+    case DB_ENGINE_MSSQL:
+        testRDBMSversion = testRDBMSVersionSelector.find("[label='MSSQL']").children()[0].value;
+        break;
+    case DB_ENGINE_POSTGRESQL:
+        testRDBMSversion = testRDBMSVersionSelector.find("[label='PostgreSQL']").children()[0].value;
+        break;
+    case DB_ENGINE_APACHEDERBY:
+        testRDBMSversion = testRDBMSVersionSelector.find("[label='Derby']").children()[0].value;
+        break;
+    case "generic":
+        testRDBMSversion = testRDBMSVersionSelector.find("[label='Generic']").children()[0].value;
+        break;
+    }
+    if (testRDBMSversion != null && testRDBMSversion != undefined){
+        $("#ds-db-version-select").val(testRDBMSversion);
+    }
+}
+
+/**
  * This function is used to verify metadata of existing datasources.
  *
  * @param root Document root object.


### PR DESCRIPTION
In Create\Edit Datasource wizard, When Database engine changes, automatically set the test connection's RDBMS version.

Related Issue: https://github.com/wso2/devstudio-tooling-ei/issues/778