### PR TITLE
Fixed: Issue 792

### DIFF
--- a/plugins/org.wso2.developerstudio.eclipse.ds.editor/DSSEditor/assets/js/data-handler.js
+++ b/plugins/org.wso2.developerstudio.eclipse.ds.editor/DSSEditor/assets/js/data-handler.js
@@ -193,8 +193,8 @@ $(document).ready(function ($) {
     });
 
     $("#ds-datasource-add-btn").click(function() {
-        resetDSAddEditModal();
         $("#create-ds-form").trigger('reset');
+        resetDSAddEditModal();
         openDSModal(false);
     });
 


### PR DESCRIPTION
Trying to configure the create datasource wizard before clearing the values. Hence configuration is done according to the values in previously created form. Changed the order so that form values are cleared before configuring the wizard.

Related Issue: https://github.com/wso2/devstudio-tooling-ei/issues/792