### PR TITLE
Fixed: Issue 786

### DIFF
--- a/plugins/org.wso2.developerstudio.eclipse.ds.editor/DSSEditor/assets/js/data-handler.js
+++ b/plugins/org.wso2.developerstudio.eclipse.ds.editor/DSSEditor/assets/js/data-handler.js
@@ -97,7 +97,7 @@ $(document).ready(function ($) {
             } else {
             	let authProvider = root.getElementsByTagName("data")[0].getElementsByTagName("authorization_provider");
             	if (authProvider.length > 0) {
-            		root.getElementsByTagName("data")[0].appendChild(authProvider[0]);
+            		root.getElementsByTagName("data")[0].removeChild(authProvider[0]);
             	}
             }
             saveAll(root, url, function() { });


### PR DESCRIPTION
Deleting the authorization provider class name does not result in removing it. This is because when provider class is empty, previous element related to class is added again instead of removing.

Related Issue: https://github.com/wso2/devstudio-tooling-ei/issues/786