### PR TITLE
Change URL format of Derby

### DIFF
--- a/plugins/org.wso2.developerstudio.eclipse.ds.editor/DSSEditor/assets/js/constants.js
+++ b/plugins/org.wso2.developerstudio.eclipse.ds.editor/DSSEditor/assets/js/constants.js
@@ -57,7 +57,7 @@ const DEFAULT_POSTGRESQL_DRIVER_CLASS = "org.postgresql.Driver";
 const DEFAULT_POSTGRESQL_URL = "jdbc:postgresql://[HOST]:[PORT5432]/[database]";
 //// Apache Derby
 const DEFAULT_DERBY_DRIVER_CLASS = "org.apache.derby.jdbc.EmbeddedDriver";
-const DEFAULT_DERBY_URL = "jdbc:derby:[path-to-data-file]";
+const DEFAULT_DERBY_URL = "jdbc:derby://[HOST]:[PORT]/[database]";
 //// IBM DB2
 const DEFAULT_IBMDB2_DRIVER_CLASS = "com.ibm.db2.jcc.DB2Driver";
 const DEFAULT_IBMDB2_URL = "jdbc:db2:[database]";

--- a/plugins/org.wso2.developerstudio.eclipse.ds.editor/DSSEditor/assets/js/datasources-util.js
+++ b/plugins/org.wso2.developerstudio.eclipse.ds.editor/DSSEditor/assets/js/datasources-util.js
@@ -753,6 +753,7 @@ function populateDSTestConDetails(urlStr) {
         switch (dbEngine) {
         case "mysql":
         case "postgresql":
+        case "derby":
             if (urlStr.match(/.+\/\/.*:.+/)) {
                 url = urlStr.split(delimiterUrl)[1].split(delimiterColon);
                 host = url[0];
@@ -776,7 +777,6 @@ function populateDSTestConDetails(urlStr) {
                 dbname = url[1].split(delimiterSlash)[1];
             }
             break;
-        case "derby":
         case "hsqldb":
         case "db2":
             url = urlStr.split(delimiterColon);


### PR DESCRIPTION
Change the URL format of the Apache Derby Database engine in the Create/Edit Datasource wizard.

Related Issue: https://github.com/wso2/devstudio-tooling-ei/issues/705