### PR TITLE
Get password for test connection when secret alias enabled

### DIFF
--- a/plugins/org.wso2.developerstudio.eclipse.ds.editor/DSSEditor/assets/js/data-handler.js
+++ b/plugins/org.wso2.developerstudio.eclipse.ds.editor/DSSEditor/assets/js/data-handler.js
@@ -111,9 +111,11 @@ $(document).ready(function ($) {
         if (this.checked) {
         	$('#ds-password-inputgroup').toggle(false);
         	$('#ds-password-sa-inputgroup').toggle(true);
+        	$('#ds-test-password-sa-inputgroup').toggle(true);
         } else {
         	$('#ds-password-inputgroup').toggle(true);
         	$('#ds-password-sa-inputgroup').toggle(false);
+        	$('#ds-test-password-sa-inputgroup').toggle(false);
         }
     });
     
@@ -209,6 +211,10 @@ $(document).ready(function ($) {
         let username = $("#ds-username-input").val();
         let password = $("#ds-password-input").val();
         
+        if ($("#ds-secret-alias-check").is(":checked")) {
+            password = $("#ds-test-password-sa").val();
+        }
+
         if (dbType == "") {
         	showDSNotification("danger", "Please select the database engine.", 6000);
         	return false;

--- a/plugins/org.wso2.developerstudio.eclipse.ds.editor/DSSEditor/assets/js/datasources-util.js
+++ b/plugins/org.wso2.developerstudio.eclipse.ds.editor/DSSEditor/assets/js/datasources-util.js
@@ -98,6 +98,7 @@ function populateDSModal(root, dsId, metadata) {
     $("#ds-secret-alias-check").prop('checked', false);
     $('#ds-password-inputgroup').toggle(true);
     $('#ds-password-sa-inputgroup').toggle(false);
+    $('#ds-test-password-sa-inputgroup').toggle(false);
 
     for (let i = 0, len = dsConfigs.length; i < len; i++) {
         let config = dsConfigs[i];
@@ -160,6 +161,7 @@ function populateDSModal(root, dsId, metadata) {
                         $("#ds-secret-alias-check").prop('checked', true);
                         $('#ds-password-inputgroup').toggle(false);
                         $('#ds-password-sa-inputgroup').toggle(true);
+                        $('#ds-test-password-sa-inputgroup').toggle(true);
                         
                     } else {
                         password = getDSConfigPropertyValue(properties, "password");
@@ -565,6 +567,7 @@ function getDSConfigPropertyValue(propertyArr, propertyName) {
 function resetDSAddEditModal() {
     setVisibleDSTypeRDBMS(true);
     $('#ds-password-sa-inputgroup').toggle(false);
+    $('#ds-test-password-sa-inputgroup').toggle(false);
     setVisibleDSTypeCarbon(false);
     clearDynamicAuthTable();
 }

--- a/plugins/org.wso2.developerstudio.eclipse.ds.editor/DSSEditor/index.html
+++ b/plugins/org.wso2.developerstudio.eclipse.ds.editor/DSSEditor/index.html
@@ -386,6 +386,9 @@
                                 <div id="ds-dbname-inputgroup"
                                      class="field inputgroup" style="margin-left: 20px;"><input type="text" placeholder=" " class="form-control" id="ds-dbname-input" name="ds-dbname-input" /><label class="mb-0 justify-content-md-start justify-content-sm-start" for="ds-dbname-input">DB Name</label></div>
                             </div>
+                            <div class="form-group">
+                                <div id="ds-test-password-sa-inputgroup" class="field inputgroup"><input type="text" placeholder=" " class="form-control" id="ds-test-password-sa" name="ds-test-password-sa" /><label class="mb-0 justify-content-md-start justify-content-sm-start" for="ds-test-password-sa">Password</label></div>
+                            </div>
                             <div class="form-group d-xl-flex form-inline"><label>RDBMS Version</label><select class="form-control" id="ds-db-version-select" style="margin-left: 5px;margin-right: 0;"><optgroup label="MySQL"><option value="8_0_15" selected>v8.0.15</option><option value="5_1_47">v5.1.47</option></optgroup><optgroup label="MSSQL"><option value="7_20_0">v7.20.0</option><option value="6_4_0">v6.4.0</option></optgroup><optgroup label="PostgreSQL"><option value="42_2_11">v42.2.11</option></optgroup><optgroup label="Generic"><option value="4_50_1">v4.50.1</option></optgroup><optgroup label="Derby"><option value="10_14_2_0">v10.14.2.0</option></optgroup></select>
                                 <button
                                         class="btn btn-secondary btn-sm d-lg-flex justify-content-xl-end" type="button" id="ds-test-conn-btn" style="margin-left: 15px;">Test Connection</button>


### PR DESCRIPTION
Add a password fields to the data source test connection section which will only be enable when the secret alias is enabled.

Related Issues: 
https://github.com/wso2/devstudio-tooling-ei/issues/798
https://github.com/wso2/devstudio-tooling-ei/issues/799