### PR TITLE
Avoid duplicate query entries at edit

### DIFF
--- a/plugins/org.wso2.developerstudio.eclipse.ds.editor/DSSEditor/assets/js/query-util.js
+++ b/plugins/org.wso2.developerstudio.eclipse.ds.editor/DSSEditor/assets/js/query-util.js
@@ -517,7 +517,7 @@ function addQuery(root, queryElement) {
         	if (qId == undefined) {
         		qId = queries[0].attributes.getNamedItem("id").value;
         	}
-            if (qId == queryId && !$("#q-query-id-input").prop('disabled')) {
+            if (qId == queryId) {
             	// Delete the node.
             	exists = true;
             	dataRoot.removeChild(queries[0]);


### PR DESCRIPTION


## Purpose
Avoid getting duplicate query entries at the query edit operation.