### PR TITLE
When H2 database selected, set test connection

### DIFF
--- a/plugins/org.wso2.developerstudio.eclipse.ds.editor/DSSEditor/assets/js/datasources-util.js
+++ b/plugins/org.wso2.developerstudio.eclipse.ds.editor/DSSEditor/assets/js/datasources-util.js
@@ -863,6 +863,9 @@ function setTestConnectionRDBMSVersion(dbEngineType) {
     case "generic":
         testRDBMSversion = testRDBMSVersionSelector.find("[label='Generic']").children()[0].value;
         break;
+    case DB_ENGINE_H2:
+        testRDBMSversion = testRDBMSVersionSelector.find("[label='H2']").children()[0].value;
+        break;
     }
     if (testRDBMSversion != null && testRDBMSversion != undefined){
         $("#ds-db-version-select").val(testRDBMSversion);


### PR DESCRIPTION
When Database engine changes, automatically set the test connection's RDBMS version.

Extending the solution in https://github.com/wso2/devstudio-tooling-dss/pull/157 to support for H2 database as well.

Related Issue: https://github.com/wso2/devstudio-tooling-ei/issues/778