### PR TITLE
Fix: Issue 1016

### DIFF
--- a/plugins/org.wso2.developerstudio.eclipse.ds.editor/DSSEditor/assets/js/query-util.js
+++ b/plugins/org.wso2.developerstudio.eclipse.ds.editor/DSSEditor/assets/js/query-util.js
@@ -528,7 +528,7 @@ function isMongoDB(datasourceConfig) {
 	let url = "http://127.0.0.1:" + portValue + "/dsseditor/service";
 	let db_type = retrieveDSMetadata(datasourceConfig, url)
 
-	return db_type.includes("mongodb_ds");
+	return db_type.indexOf("mongodb_ds") != -1;
 }
 
 function addQuery(root, queryElement) {


### PR DESCRIPTION
Fix query fails to save. This is because saving invokes .includes function which does not support in windows browser environment.

Related Issue: https://github.com/wso2/devstudio-tooling-ei/issues/1016