### PR TITLE
[DSS] Change generated input mappings sqlType and paramType to UPPERCASE

### DIFF
--- a/plugins/org.wso2.developerstudio.eclipse.ds.editor/DSSEditor/assets/js/query-util.js
+++ b/plugins/org.wso2.developerstudio.eclipse.ds.editor/DSSEditor/assets/js/query-util.js
@@ -766,8 +766,8 @@ function populateWithMappings(root, mappings) {
             let paramElement = root.createElement("param");
 
             paramElement.setAttribute("name", mappings[i]);
-            paramElement.setAttribute("paramType", "scalar");
-            paramElement.setAttribute("sqlType", "string");
+            paramElement.setAttribute("paramType", "SCALAR");
+            paramElement.setAttribute("sqlType", "STRING");
 
             window.params.push(paramElement);
         }


### PR DESCRIPTION
## Purpose
Change default values to UPPERCASE to avoid errors when deploying.

Related Issue: https://github.com/wso2/devstudio-tooling-ei/issues/1032