### PR TITLE
Fix: Test connection details are not automatically populating

### DIFF
--- a/plugins/org.wso2.developerstudio.eclipse.ds.editor/DSSEditor/assets/js/datasources-util.js
+++ b/plugins/org.wso2.developerstudio.eclipse.ds.editor/DSSEditor/assets/js/datasources-util.js
@@ -141,16 +141,17 @@ function populateDSModal(root, dsId, metadata) {
                     // url
                     let url = getDSConfigPropertyValue(properties, "url");
 
-                    // populate data source test connection details from url
-                    if ((url != null && url != "") && url != undefined){
-                        populateDSTestConDetails(url);
-                    }
                     if (url === "") {
                         url = getDSConfigPropertyValue(properties, "org.wso2.ws.dataservice.protocol");
                     }
 
                     if (url != null && url != undefined) {
                         $("#ds-url-input").val(url.trim());
+                        
+                        // populate data source test connection details from url
+                        if (url != "") {
+                            populateDSTestConDetails(url.trim());
+                        }
                     }
 
                     // username


### PR DESCRIPTION
Issue: Trying to populate testConnectionDetails before setting the URL. 
Fix: Moving the populating code to the proper place.

Related Issue: https://github.com/wso2/devstudio-tooling-ei/issues/1040