### PR TITLE
Fix: Pass project nature before project creation.

### DIFF
--- a/plugins/org.wso2.developerstudio.eclipse.artifact.dataserviceProject/src/org/wso2/developerstudio/eclipse/artifact/dataserviceProject/ui/wizard/DataServiceProjectCreationWizard.java
+++ b/plugins/org.wso2.developerstudio.eclipse.artifact.dataserviceProject/src/org/wso2/developerstudio/eclipse/artifact/dataserviceProject/ui/wizard/DataServiceProjectCreationWizard.java
@@ -77,6 +77,7 @@ public class DataServiceProjectCreationWizard extends AbstractWSO2ProjectCreatio
 
 	public boolean performFinish() {
 		try {
+			setProjectNature(DS_PROJECT_NATURE);
 			// creates a new project
 			project = createNewProject();
 

--- a/plugins/org.wso2.developerstudio.eclipse.artifact.datasourceproject/src/org/wso2/developerstudio/eclipse/artifact/datasourceProject/ui/wizard/DataSourceProjectCreationWizard.java
+++ b/plugins/org.wso2.developerstudio.eclipse.artifact.datasourceproject/src/org/wso2/developerstudio/eclipse/artifact/datasourceProject/ui/wizard/DataSourceProjectCreationWizard.java
@@ -65,6 +65,7 @@ public class DataSourceProjectCreationWizard extends AbstractWSO2ProjectCreation
 
 	public boolean performFinish() {
 		try {
+			setProjectNature(DS_PROJECT_NATURE);
 			// creates a new project
 			project = createNewProject();
 


### PR DESCRIPTION
## Purpose
Set project nature of the following projects:

1. Data Source project
2. Data Service Project

Related Issue: https://github.com/wso2/devstudio-tooling-ei/issues/1046