### PR TITLE
Fix: Edit output mapping shows incorrect data

### DIFF
--- a/plugins/org.wso2.developerstudio.eclipse.ds.editor/DSSEditor/assets/js/q-output-mapping-validation.js
+++ b/plugins/org.wso2.developerstudio.eclipse.ds.editor/DSSEditor/assets/js/q-output-mapping-validation.js
@@ -323,13 +323,13 @@ function populateElementModal(result, tds) {
 		 let name = ele.attributes.getNamedItem("name").value;
 		 if (name == tds[0].innerText) {
 			 let dsType = tds[1].innerText;
-			 if (dsType == "column" && ele.attributes.getNamedItem("column") != null) {
+			 if (dsType == "column") {
 				 $('#q-om-addedit-mappingtype-select').val('element');
 				 $('#q-om-addedit-dsmapping-select').val('column');
 				 $('#q-om-addedit-outputfn-input').val(name);
 				 setNamespaceValues(ele);
 				 
-				 $('#q-om-addedit-dscolname-input').val(ele.attributes.getNamedItem("column").value);
+				 $('#q-om-addedit-dscolname-input').val(getAttributeValue(ele, 'column'));
 				 setParamaterTypeValues(ele);
 				 let paramTypeVal = tds[5].innerText;
 				 if (paramTypeVal.indexOf(":") != -1) {
@@ -345,12 +345,12 @@ function populateElementModal(result, tds) {
 				 
 				 break;
 				 
-			 } else if (dsType == "query-param" && ele.attributes.getNamedItem("query-param") != null) {
+			 } else if (dsType == "query-param") {
 				 $('#q-om-addedit-mappingtype-select').val('element');
 				 $('#q-om-addedit-dsmapping-select').val('query-param');
 				 $('#q-om-addedit-outputfn-input').val(name);
 				 setNamespaceValues(ele);
-				 $('#q-om-addedit-qparamname-input').val(ele.attributes.getNamedItem("query-param").value);
+				 $('#q-om-addedit-qparamname-input').val(getAttributeValue(ele, "query-param"));
 				 setParamaterTypeValues(ele);
 				 $('#q-om-paramtype-select').val(tds[5].innerText);
 				 setOptionalValue(ele);
@@ -382,6 +382,17 @@ function populateElementModal(result, tds) {
 			 }
 		}
 	}
+}
+
+/*
+ * Validate attribute and returns attribute value.
+ */
+function getAttributeValue(element, attributeName) {
+	let attribute = element.attributes.getNamedItem(attributeName);
+	if (attribute != null && attribute != undefined) {
+		return attribute.value;
+	}
+	return EMPTY_STRING;
 }
 
 function setNamespaceValues(ele) {


### PR DESCRIPTION
When trying to edit output mappings that do not have certain fields, edit output mapping wizard does not get populated. Hence, the values from the previously opened will be shown.
Fix: Allow to edit output mappings without certain fields by populating missing fields with empty strings.

Related Issue: https://github.com/wso2/devstudio-tooling-ei/issues/830