### PR TITLE
Rename project wizard extensions

### DIFF
--- a/plugins/org.wso2.developerstudio.eclipse.artifact.dataserviceProject/plugin.xml
+++ b/plugins/org.wso2.developerstudio.eclipse.artifact.dataserviceProject/plugin.xml
@@ -3,13 +3,13 @@
 <plugin>
    <extension
          point="org.eclipse.ui.newWizards">
-         <wizard name="Data Service Project" category="org.wso2.developerstudio.eclipse.capp.project/org.wso2.developerstudio.eclipse.service.hosting/org.wso2.developerstudio.eclipse.service.hosting.project.types"
+         <wizard name="Data Service Configs" category="org.wso2.developerstudio.eclipse.capp.project/org.wso2.developerstudio.eclipse.service.hosting/org.wso2.developerstudio.eclipse.service.hosting.project.types"
 			class="org.wso2.developerstudio.eclipse.artifact.dataserviceProject.ui.wizard.DataServiceProjectCreationWizard"
 			wizardManifest="project_wizard.xml"
 			id="org.wso2.developerstudio.eclipse.artifact.newdsproject"
 			project="true"
 			icon="icons/ds-16x16.png">
-			<description>Data Service Project</description>
+			<description>Data Service Configs</description>
 		</wizard>
    </extension>
    <extension point="org.wso2.developerstudio.eclipse.capp.artifacts.provider">

--- a/plugins/org.wso2.developerstudio.eclipse.artifact.datasourceproject/plugin.xml
+++ b/plugins/org.wso2.developerstudio.eclipse.artifact.datasourceproject/plugin.xml
@@ -8,10 +8,10 @@
                class="org.wso2.developerstudio.eclipse.artifact.datasourceProject.ui.wizard.DataSourceProjectCreationWizard"
                icon="icons/ds-16x16.png"
                id="org.wso2.developerstudio.eclipse.artifact.newdatasourceproject"
-               name="Data Source Project"
+               name="Data Source Configs"
                project="true"
                wizardManifest="project_wizard.xml">
-			<description>Data Source Project</description>
+			<description>Data Source Configs</description>
 		</wizard>
    </extension>
       <extension point="org.wso2.developerstudio.eclipse.capp.artifacts.provider">


### PR DESCRIPTION
Rename project wizard extensions of data service and data source modules.

Fix https://github.com/wso2/devstudio-tooling-ei/issues/1212