### PR TITLE
Revert "add changes to build pom file for eclipse 2020 migration"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,7 +79,7 @@
                 <checksumPolicy>ignore</checksumPolicy>
             </releases>
             <id>Eclipse-p2-repo</id>
-            <url>http://download.eclipse.org/releases/2020-06/</url>
+            <url>http://download.eclipse.org/releases/oxygen/</url>
             <layout>p2</layout>
         </repository>
         <repository>
@@ -262,12 +262,27 @@
                         <environment>
                             <os>linux</os>
                             <ws>gtk</ws>
+                            <arch>x86</arch>
+                        </environment>
+                        <environment>
+                            <os>linux</os>
+                            <ws>gtk</ws>
                             <arch>x86_64</arch>
                         </environment>
                         <environment>
                             <os>win32</os>
                             <ws>win32</ws>
+                            <arch>x86</arch>
+                        </environment>
+                        <environment>
+                            <os>win32</os>
+                            <ws>win32</ws>
                             <arch>x86_64</arch>
+                        </environment>
+                        <environment>
+                            <os>macosx</os>
+                            <ws>cocoa</ws>
+                            <arch>x86</arch>
                         </environment>
                         <environment>
                             <os>macosx</os>


### PR DESCRIPTION
Reverts wso2/devstudio-tooling-dss#216
Moved eclipse migration-related commit to a new branch "eclipse-2020-migration"